### PR TITLE
Use new hashes to avoid refetch

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,8 @@
 .{
-    .name = "libpng",
+    .name = .libpng,
     .version = "1.6.43",
-    .minimum_zig_version = "0.13.0",
+    .fingerprint = 0xb7a09eb4a7615dd1,
+    .minimum_zig_version = "0.14.0",
     .paths = .{
         "LICENSE",
         "build.zig",
@@ -11,12 +12,12 @@
     .dependencies = .{
         .libpng = .{
             .url = "https://github.com/glennrp/libpng/archive/refs/tags/v1.6.43.tar.gz",
-            .hash = "1220aa013f0c83da3fb64ea6d327f9173fa008d10e28bc9349eac3463457723b1c66",
+            .hash = "N-V-__8AAJrvXQCqAT8Mg9o_tk6m0yf5Fz-gCNEOKLyTSerD",
         },
 
         .zlib = .{
-            .url = "https://github.com/allyourcodebase/zlib/archive/refs/tags/1.3.1.tar.gz",
-            .hash = "122034ab2a12adf8016ffa76e48b4be3245ffd305193edba4d83058adbcfa749c107",
+            .url = "git+https://github.com/allyourcodebase/zlib#6c72830882690c1eb2567a537525c3f432c1da50",
+            .hash = "zlib-1.3.1-ZZQ7lVgMAACwO4nUUd8GLhsuQ5JQq_VAhlEiENJTUv6h",
         },
     },
 }


### PR DESCRIPTION
- Bump minimum Zig version to 0.14.0
- Use new hash format for upstream libpng
- Use new hash format (and point to newer commit) for zlib